### PR TITLE
Add hooks for bind-exporter relation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-ops >= 1.2.0
+# NOTE (rgildein): This is required due to the use of harness.remove_relation, which is
+#                  not yet part of the latest release. This can be deleted after a new
+#                  release.
+git+https://github.com/canonical/operator.git#egg=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,8 +9,9 @@
 
 import logging
 import subprocess
+from ipaddress import IPv4Address
 
-from ops.charm import CharmBase
+from ops.charm import CharmBase, RelationChangedEvent, RelationDepartedEvent
 from ops.framework import StoredState
 from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus
@@ -30,9 +31,34 @@ class PrometheusBindExporterOperatorCharm(CharmBase):
         super().__init__(*args)
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+        # relation
+        self.framework.observe(self.on.bind_exporter_relation_joined,
+                               self._on_bind_exporter_relation_changed)
+        self.framework.observe(self.on.bind_exporter_relation_changed,
+                               self._on_bind_exporter_relation_changed)
+        self.framework.observe(self.on.bind_exporter_relation_departed,
+                               self._on_prometheus_relation_departed)
+        # initialise stored data
         self._stored.set_default(listen_port=DEFAULT_LISTEN_PORT,
                                  stats_groups=DEFAULT_STATS_GROUPS,)
+
         self.unit.status = ActiveStatus("Unit is ready")
+
+    def _manage_prometheus_bind_exporter_service(self):
+        """Manage the prometheus-bind-exporter service."""
+        logger.debug("prometheus-bind-exporter configuration in progress")
+        subprocess.check_call([
+            "snap", "set", "prometheus-bind-exporter",
+            f"web.listen-address={self.private_address or ''}:{self._stored.listen_port}",
+            f"web.stats-groups={self._stored.stats_groups}"
+        ])
+        logger.info("prometheus-bind-exporter has been reconfigured")
+
+    @property
+    def private_address(self) -> str:
+        """Returning the private address of unit."""
+        address: IPv4Address = self.model.get_binding("bind-stats").network.bind_address
+        return str(address)
 
     def _on_install(self, _):
         """Installation hook that installs prometheus-bind-exporter daemon."""
@@ -48,18 +74,34 @@ class PrometheusBindExporterOperatorCharm(CharmBase):
         self._stored.listen_port = self.config.get("exporter-listen-port")
         self._stored.stats_groups = self.config.get("exporter-stats-groups")
         self._manage_prometheus_bind_exporter_service()
+
+        # update relation data
+        bind_exporter_relation = self.model.get_relation("bind-exporter")
+        if bind_exporter_relation:
+            logger.info("Updating `bind-exporter` relation data.")
+            bind_exporter_relation.data[self.unit].update({
+                "hostname": self.private_address, "port": str(self._stored.listen_port)
+            })
+
         self.unit.status = ActiveStatus("Unit is ready")
 
-    def _manage_prometheus_bind_exporter_service(self):
-        """Manage the prometheus-bind-exporter service."""
-        logger.debug("prometheus-bind-exporter configuration in progress")
-        private_address = self.model.get_binding("designate-bind").network.bind_address
-        subprocess.check_call([
-            "snap", "set", "prometheus-bind-exporter",
-            f"web.listen-address={private_address or ''}:{self._stored.listen_port}",
-            f"web.stats-groups={self._stored.stats_groups}"
-        ])
-        logger.info("prometheus-bind-exporter has been reconfigured")
+    def _on_bind_exporter_relation_changed(self, event: RelationChangedEvent):
+        """Prometheus relation changed hook.
+
+        This hook will ensure the creation of a new target in Prometheus.
+        """
+        logger.info("Registering new `%s` target in Prometheus.", self.unit.name)
+        event.relation.data[self.unit].update({
+            "hostname": self.private_address, "port": str(self._stored.listen_port)
+        })
+
+    def _on_prometheus_relation_departed(self, event: RelationDepartedEvent):
+        """Prometheus relation departed hook.
+
+        This hook will ensure the deletion of the target in Prometheus.
+        """
+        logger.info("Removing `%s` target from Prometheus.")
+        event.relation.data[self.unit].clear()
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,7 +46,9 @@ class PrometheusBindExporterOperatorCharm(CharmBase):
 
     def _manage_prometheus_bind_exporter_service(self):
         """Manage the prometheus-bind-exporter service."""
-        logger.debug("prometheus-bind-exporter configuration in progress")
+        logger.debug("prometheus-bind-exporter configuration [web.listen-address=%s:%s, "
+                     "web.stats-groups=%s] in progress", self.private_address or "",
+                     self._stored.listen_port, self._stored.stats_groups)
         subprocess.check_call([
             "snap", "set", "prometheus-bind-exporter",
             f"web.listen-address={self.private_address or ''}:{self._stored.listen_port}",
@@ -56,7 +58,7 @@ class PrometheusBindExporterOperatorCharm(CharmBase):
 
     @property
     def private_address(self) -> str:
-        """Returning the private address of unit."""
+        """Return the private address of unit."""
         address: IPv4Address = self.model.get_binding("bind-stats").network.bind_address
         return str(address)
 
@@ -90,7 +92,7 @@ class PrometheusBindExporterOperatorCharm(CharmBase):
 
         This hook will ensure the creation of a new target in Prometheus.
         """
-        logger.info("Registering new `%s` target in Prometheus.", self.unit.name)
+        logger.info("Shared relation data with %s", self.unit.name)
         event.relation.data[self.unit].update({
             "hostname": self.private_address, "port": str(self._stored.listen_port)
         })
@@ -100,7 +102,7 @@ class PrometheusBindExporterOperatorCharm(CharmBase):
 
         This hook will ensure the deletion of the target in Prometheus.
         """
-        logger.info("Removing `%s` target from Prometheus.")
+        logger.info("Removing %s target from Prometheus.")
         event.relation.data[self.unit].clear()
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,21 +6,27 @@ import unittest
 from unittest import mock
 
 import charm
+from ops.model import Unit
 from ops.testing import Harness
 
 
-class TestInitCharm(unittest.TestCase):
+class TestCharm(unittest.TestCase):
+    def assert_active_unit(self, unit: Unit):
+        self.assertEqual(unit.status.name, "active")
+        self.assertEqual(unit.status.message, "Unit is ready")
+
+
+class TestInitCharm(TestCharm):
 
     def test_init(self):
         """Test initialization of charm."""
         harness = Harness(charm.PrometheusBindExporterOperatorCharm)
         harness.begin()
 
-        self.assertEqual(harness.charm.unit.status.name, "active")
-        self.assertEqual(harness.charm.unit.status.message, "Unit is ready")
+        self.assert_active_unit(harness.charm.unit)
 
 
-class TestCharm(unittest.TestCase):
+class TestCharmHooks(TestCharm):
 
     def patch(self, obj, method):
         """Mock the method."""
@@ -43,6 +49,12 @@ class TestCharm(unittest.TestCase):
         self.mock_fetch = self.patch(self.harness.model.resources, "fetch")
         self.mock_fetch.return_value = "prometheus-bind-exporter.snap"
 
+    def _add_bind_exporter_relation(self):
+        """Help function to add bind-exporter relation."""
+        relation_id = self.harness.add_relation("bind-exporter", "prometheus2")
+        self.harness.add_relation_unit(relation_id, "prometheus2/0")
+        return relation_id
+
     def test_manage_prometheus_bind_exporter_service(self):
         """Test manage the prometheus-bind-exporter snap."""
         self.harness.charm._manage_prometheus_bind_exporter_service()
@@ -52,6 +64,11 @@ class TestCharm(unittest.TestCase):
              "web.listen-address=127.0.0.1:9119",
              "web.stats-groups=server,view,tasks"])
 
+    def test_private_address(self):
+        """Test help function to get private address."""
+        address = self.harness.charm.private_address
+        self.assertEqual("127.0.0.1", address)
+
     def test_on_install(self):
         """Test install hook."""
         exp_call = mock.call(["snap", "install", "--dangerous",
@@ -60,9 +77,7 @@ class TestCharm(unittest.TestCase):
 
         self.mock_fetch.assert_called_once_with("prometheus-bind-exporter")
         self.assertIn(exp_call, self.mock_subprocess.check_call.mock_calls)
-        self.assertEqual(self.harness.charm.unit.status.name, "active")
-        self.assertEqual(self.harness.charm.unit.status.message,
-                         "Unit is ready")
+        self.assert_active_unit(self.harness.charm.unit)
 
     def test_on_config_changed(self):
         """Test config-changed hook."""
@@ -76,6 +91,32 @@ class TestCharm(unittest.TestCase):
             ["snap", "set", "prometheus-bind-exporter",
              "web.listen-address=127.0.0.1:9120",
              "web.stats-groups=server"])
-        self.assertEqual(self.harness.charm.unit.status.name, "active")
-        self.assertEqual(self.harness.charm.unit.status.message,
-                         "Unit is ready")
+        self.assert_active_unit(self.harness.charm.unit)
+
+    def test_on_config_changed_with_bind_exporter_relation(self):
+        """Test config-changed hook with existing bind-exporter relation."""
+        relation_id = self._add_bind_exporter_relation()
+        self.harness.update_config({"exporter-listen-port": "9120"})
+
+        relation_data = self.harness.get_relation_data(relation_id, self.harness.charm.unit.name)
+        self.assertDictEqual(relation_data, {"hostname": "127.0.0.1", "port": "9120"})
+        self.assert_active_unit(self.harness.charm.unit)
+
+    def test_on_bind_exporter_relation_changed(self):
+        """Test Prometheus relation changed hook."""
+        relation_id = self._add_bind_exporter_relation()
+        # update relation -> trigger bind_exporter_relation_changed hook
+        self.harness.update_relation_data(relation_id, "prometheus2/0", {})
+
+        relation_data = self.harness.get_relation_data(relation_id, self.harness.charm.unit.name)
+        self.assertDictEqual(relation_data, {"hostname": "127.0.0.1", "port": "9119"})
+        self.assert_active_unit(self.harness.charm.unit)
+
+    def test_on_prometheus_relation_departed(self):
+        """Test Prometheus relation changed hook."""
+        relation_id = self._add_bind_exporter_relation()
+        # remove relation -> trigger bind_exporter_departed hook
+        self.harness.remove_relation(relation_id)
+
+        self.assertEqual(0, len(self.harness.model.relations.get("bind-exporter")))
+        self.assert_active_unit(self.harness.charm.unit)

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,4 @@ deps =
     pytest
 commands =
     coverage run --branch --source={toxinidir}/src -m pytest -v {posargs}
-    coverage report -m --fail-under 90
+    coverage report -m --fail-under 97


### PR DESCRIPTION
 - add prometheus_relation_changed hook to create a new target
 - add prometheus_relation_departed hook to remove the target
 - update bind-exporter relation data if config changed